### PR TITLE
ABSCAN-1481: update deps for GHC-9.2.5

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+## [0.1.5.1] - 2023-01-17
+- Update dependencies for Haskell LTS-20.4.
+
 ## [0.1.5.0] - 2022-09-30
 ### Changed
 - Update FASTA parser to megaparsec.

--- a/default.nix
+++ b/default.nix
@@ -9,4 +9,5 @@ bcd-lts.mkBiocadProject {
   shellArgs = {
     buildInputs = [ bcd-lts.pkgs.RNA ];
   };
+  compiler = "ghc925";
 }

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                cobot-io
-version:             0.1.5.0
+version:             0.1.5.1
 github:              "biocad/cobot-io"
 license:             BSD3
 category:            Bio
@@ -44,7 +44,7 @@ dependencies:
 - deepseq >= 1.4 && < 1.5
 - filepath
 - http-conduit >= 2.3 && < 2.4
-- hyraxAbif >= 0.2.3.27 && < 0.2.4.0
+- hyraxAbif >= 0.2.3.27 && < 0.2.5.0
 - lens >= 4.16 && < 5.3
 - linear >= 1.20 && < 1.23
 - megaparsec >= 9.0.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-17.5
+resolver: lts-20.4
 
 packages:
 - .
@@ -6,8 +6,8 @@ packages:
 extra-deps:
 - data-msgpack-0.0.13
 - data-msgpack-types-0.0.3
-- hyraxAbif-0.2.3.27
 - cobot-0.1.1.7
+- hyraxAbif-0.2.4.2
 
 ghc-options:
   $locals: -Wall -fdiagnostics-color=always


### PR DESCRIPTION
Update dependencies for moving to LTS-20.4 (GHC-9.2.5).